### PR TITLE
Add spork to help resolve forks

### DIFF
--- a/src/rpc/misc.cpp
+++ b/src/rpc/misc.cpp
@@ -285,6 +285,7 @@ UniValue spork(const JSONRPCRequest& request)
 
         //broadcast new spork
         if(sporkManager.UpdateSpork(nSporkID, nValue, *g_connman)){
+            sporkManager.ExecuteSpork(nSporkID, nValue);
             return "success";
         } else {
             throw std::runtime_error(

--- a/src/spork.h
+++ b/src/spork.h
@@ -23,6 +23,7 @@ static const int SPORK_5_INSTANTSEND_MAX_VALUE                          = 10004;
 static const int SPORK_6_NEW_SIGS                                       = 10005;
 static const int SPORK_8_MASTERNODE_PAYMENT_ENFORCEMENT                 = 10007;
 static const int SPORK_9_SUPERBLOCKS_ENABLED                            = 10008;
+static const int SPORK_12_RECONSIDER_BLOCKS                             = 10011;
 static const int SPORK_14_REQUIRE_SENTINEL_FLAG                         = 10013;
 
 static const int SPORK_START                                            = SPORK_2_INSTANTSEND_ENABLED;
@@ -95,6 +96,7 @@ public:
     CSporkManager() {}
 
     void ProcessSpork(CNode* pfrom, const std::string& strCommand, CDataStream& vRecv, CConnman& connman);
+    void ExecuteSpork(int nSporkID, int nValue);
     bool UpdateSpork(int nSporkID, int64_t nValue, CConnman& connman);
 
     bool IsSporkActive(int nSporkID);


### PR DESCRIPTION
When using this spork you need to provide a value which sets the number of blocks to reconsider, maximum is 960 blocks.

spork SPORK_12_RECONSIDER_BLOCKS 500