### PR TITLE
Remove duplicate stream read

### DIFF
--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -2687,9 +2687,6 @@ bool static ProcessMessage(CNode* pfrom, const std::string& strCommand, CDataStr
         std::shared_ptr<CBlock> pblock = std::make_shared<CBlock>();
         vRecv >> *pblock;
 
-        CBlock block;
-        vRecv >> block;
-
         LogPrint("net", "received block %s peer=%d\n", pblock->GetHash().ToString(), pfrom->id);
 
         // Process all blocks from whitelisted peers, even if not requested,
@@ -2714,7 +2711,7 @@ bool static ProcessMessage(CNode* pfrom, const std::string& strCommand, CDataStr
 
 #ifdef ENABLE_SMESSAGE
         if (fSecMsgEnabled)
-            SecureMsgScanBlock(block);
+            SecureMsgScanBlock(*pblock);
 #endif
 
 


### PR DESCRIPTION
This stream read was being called after the main one causing a failure to process the block as the stream was already empty. Removing the duplicate stream read fixes the issue.